### PR TITLE
rename CoffeeScript\Init::init() to CoffeeScript\Init::initiate()

### DIFF
--- a/make.php
+++ b/make.php
@@ -78,7 +78,7 @@ function make()
           "<?php\n"
         . "namespace CoffeeScript;\n"
         . "use \ArrayAccess as ArrayAccess;\n"
-        . "Init::init();\n"
+        . "Init::initiate();\n"
     ));
 
     // Write.

--- a/src/CoffeeScript/Compiler.php
+++ b/src/CoffeeScript/Compiler.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 /**
  * @package   CoffeeScript

--- a/src/CoffeeScript/Error.php
+++ b/src/CoffeeScript/Error.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 class Error extends \Exception
 {

--- a/src/CoffeeScript/Helpers.php
+++ b/src/CoffeeScript/Helpers.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 class Helpers {
 

--- a/src/CoffeeScript/Init.php
+++ b/src/CoffeeScript/Init.php
@@ -10,7 +10,7 @@ class Init {
    * Dummy function that doesn't actually do anything, it's just used to make
    * sure that this file gets loaded.
    */
-  static function init() {}
+  static function initiate() {}
 
   /**
    * This function may be used in lieu of an autoloader.

--- a/src/CoffeeScript/Lexer.php
+++ b/src/CoffeeScript/Lexer.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 /**
  * CoffeeScript lexer. For the most part it's directly from the original

--- a/src/CoffeeScript/Nodes.php
+++ b/src/CoffeeScript/Nodes.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 define('LEVEL_TOP',     1);
 define('LEVEL_PAREN',   2);

--- a/src/CoffeeScript/Parser.php
+++ b/src/CoffeeScript/Parser.php
@@ -1,7 +1,7 @@
 <?php
 namespace CoffeeScript;
 use \ArrayAccess as ArrayAccess;
-Init::init();
+Init::initiate();
 
 /* Driver template for the PHP_ParserGenerator parser generator. (PHP port of LEMON)
 */

--- a/src/CoffeeScript/Rewriter.php
+++ b/src/CoffeeScript/Rewriter.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 class Rewriter
 {

--- a/src/CoffeeScript/Scope.php
+++ b/src/CoffeeScript/Scope.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 /**
  * Lexical scope manager.

--- a/src/CoffeeScript/SyntaxError.php
+++ b/src/CoffeeScript/SyntaxError.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 class SyntaxError extends Error {}
 

--- a/src/CoffeeScript/Value.php
+++ b/src/CoffeeScript/Value.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 class Value
 {

--- a/src/CoffeeScript/yy/Base.php
+++ b/src/CoffeeScript/yy/Base.php
@@ -2,7 +2,7 @@
 
 namespace CoffeeScript;
 
-Init::init();
+Init::initiate();
 
 abstract class yy_Base
 {


### PR DESCRIPTION
fixes "Fatal error: Constructor CoffeeScript\Init::init() cannot be static [...]" that accrued in some php versions.
Harro Verton mentioned [here](http://fuelphp.com/forums/discussion/comment/12437)
"[...] In PHP, for PHP4 compatibility reasons, if a class doesn't have a constructor defined, PHP will look for a method with the same name as the class. As constructors are used in object instantiation, they can not be static."