### PR TITLE
Remove call of static method `init()` on class Init

### DIFF
--- a/make.php
+++ b/make.php
@@ -111,5 +111,3 @@ function make()
 }
 
 init();
-
-?>

--- a/src/CoffeeScript/Compiler.php
+++ b/src/CoffeeScript/Compiler.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 /**
  * @package   CoffeeScript

--- a/src/CoffeeScript/Error.php
+++ b/src/CoffeeScript/Error.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 class Error extends \Exception
 {

--- a/src/CoffeeScript/Helpers.php
+++ b/src/CoffeeScript/Helpers.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 class Helpers {
 

--- a/src/CoffeeScript/Init.php
+++ b/src/CoffeeScript/Init.php
@@ -7,12 +7,6 @@ define('COFFEESCRIPT_VERSION', '1.3.1');
 class Init {
 
   /**
-   * Dummy function that doesn't actually do anything, it's just used to make
-   * sure that this file gets loaded.
-   */
-  static function init() {}
-
-  /**
    * This function may be used in lieu of an autoloader.
    */
   static function load($root = NULL)

--- a/src/CoffeeScript/Lexer.php
+++ b/src/CoffeeScript/Lexer.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 /**
  * CoffeeScript lexer. For the most part it's directly from the original

--- a/src/CoffeeScript/Nodes.php
+++ b/src/CoffeeScript/Nodes.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 define('LEVEL_TOP',     1);
 define('LEVEL_PAREN',   2);

--- a/src/CoffeeScript/Parser.php
+++ b/src/CoffeeScript/Parser.php
@@ -1,7 +1,10 @@
 <?php
 namespace CoffeeScript;
 use \ArrayAccess as ArrayAccess;
-Init::init();
+
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+};
 
 /* Driver template for the PHP_ParserGenerator parser generator. (PHP port of LEMON)
 */

--- a/src/CoffeeScript/Rewriter.php
+++ b/src/CoffeeScript/Rewriter.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 class Rewriter
 {

--- a/src/CoffeeScript/Scope.php
+++ b/src/CoffeeScript/Scope.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 /**
  * Lexical scope manager.

--- a/src/CoffeeScript/SyntaxError.php
+++ b/src/CoffeeScript/SyntaxError.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 class SyntaxError extends Error {}
 

--- a/src/CoffeeScript/Value.php
+++ b/src/CoffeeScript/Value.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 class Value
 {

--- a/src/CoffeeScript/yy/Base.php
+++ b/src/CoffeeScript/yy/Base.php
@@ -2,7 +2,9 @@
 
 namespace CoffeeScript;
 
-Init::init();
+if (! class_exists('CoffeeScript\Init')) {
+    throw new \RuntimeException('The class Init not found');
+}
 
 abstract class yy_Base
 {


### PR DESCRIPTION
Make more sense check if class Init exists on namespace to use that.
I replace the `Init::init()` with a call to the `class_exists()` its more easy
to understand, because when look the code know it is a check.