### PR TITLE
Not compatible with PHP 7 due to changes to substr

### DIFF
--- a/src/CoffeeScript/Lexer.php
+++ b/src/CoffeeScript/Lexer.php
@@ -1284,7 +1284,7 @@ class Lexer
 
   function tokenize()
   {
-    while ( ($this->chunk = substr($this->code, $this->index)) !== FALSE )
+    while ( ($this->chunk = substr($this->code, $this->index)) != FALSE )
     {
       $types = array('identifier', 'comment', 'whitespace', 'line', 'heredoc', 
         'string', 'number', 'regex', 'js', 'literal');


### PR DESCRIPTION
PHP 7 substr changes:
"If string is equal to start characters long, an empty string will be returned. Prior to this version, FALSE was returned in this case."